### PR TITLE
fix animal characteristics order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Introduction
 Welcome! This is an automated workshop that will explain how to deploy an ERC721 token on StarkNet and customize it to perform specific functions.
-It is aimed at developpers that:
+It is aimed at developers that:
 - Understand Cairo syntax
 - Understand the ERC721 token standard
 
 ​
-This workshop is the first in a serie that will cover broad smart contract concepts (writing and deploying ERC20/ERC721, bridging assets, L1 <-> L2 messaging...). 
+This workshop is the first in a series that will cover broad smart contract concepts (writing and deploying ERC20/ERC721, bridging assets, L1 <-> L2 messaging...). 
 Interested in helping writing those? [Reach out](https://twitter.com/HenriLieutaud)!
 ​
 
@@ -38,8 +38,8 @@ Your objective is to gather as many ERC721-101 points as possible. Please note :
 - The 'transfer' function of ERC721-101 has been disabled to encourage you to finish the TD with only one address
 - You can answer the various questions of this workshop with different ERC721 contracts. However, an evaluated address has only one evaluated ERC721 contract at a time. To change the evaluated ERC721 contract associated with your address, call `submit_exercise()`  within the evaluator with that specific address.
 - In order to receive points, you will have to do execute code in `Evaluator.cairo` such that the function `distribute_points(sender_address, 2)` is triggered, and distributes n points.
-- This repo contains an interface `IExerciceSolution.cairo`. Your ERC721 contract will have to conform to this interface in order to validate the exercice; that is, your contract needs to implement all the functions described in `IExerciceSolution.cairo`. 
-- A high level description of what is expected for each exercice is in this readme. A low level description of what is expected can be inferred by reading the code in `Evaluator.cairo`.
+- This repo contains an interface `IExerciceSolution.cairo`. Your ERC721 contract will have to conform to this interface in order to validate the exercise; that is, your contract needs to implement all the functions described in `IExerciceSolution.cairo`. 
+- A high level description of what is expected for each exercise is in this readme. A low level description of what is expected can be inferred by reading the code in `Evaluator.cairo`.
 - The Evaluator contract sometimes needs to make payments to buy your tokens. Make sure he has enough dummy tokens to do so! If not, you should get dummy tokens from the dummy tokens contract and send them to the evaluator
 
 
@@ -64,7 +64,7 @@ You can (and should) check the status of your transaction with the following URL
 
 ### Getting to work
 - Clone the repo on your machine
-- Setup the environment following [these instructions](https://starknet.io/docs/quickstart.html#quickstart)
+- Set up the environment following [these instructions](https://starknet.io/docs/quickstart.html#quickstart)
 - Install [Nile](https://github.com/OpenZeppelin/nile).
 - Test that you are able to compile the project
 ```

--- a/contracts/Evaluator.cairo
+++ b/contracts/Evaluator.cairo
@@ -231,8 +231,8 @@ func ex3_declare_new_animal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ra
 
 	# Retrieve expected characteristics
 	let (expected_sex) = assigned_sex_number(sender_address)
-	let (expected_wings) = assigned_wings_number(sender_address)
 	let (expected_legs) = assigned_legs_number(sender_address)
+	let (expected_wings) = assigned_wings_number(sender_address)
 
 	# Declaring a new animal with the desired parameters
 	let (created_token) = IExerciceSolution.declare_animal(contract_address = submited_exercise_address, sex=expected_sex, legs=expected_legs, wings=expected_wings)
@@ -290,11 +290,11 @@ func ex4_declare_dead_animal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, r
 
 	# Check that properties are deleted 
 	# Reading animal characteristic in student solution
-	let (read_sex, read_wings, read_legs) = IExerciceSolution.get_animal_characteristics(contract_address = submited_exercise_address, token_id=token_id)
+	let (read_sex, read_legs, read_wings) = IExerciceSolution.get_animal_characteristics(contract_address = submited_exercise_address, token_id=token_id)
 	# Checking characteristics are correct
 	assert read_sex = 0
-	assert read_wings = 0
 	assert read_legs = 0
+	assert read_wings = 0
 	# TODO Testing killing another person's animal. The caller has to hold an animal
 	# Requires try / catch, or something smarter. I'll think about it.
 	
@@ -463,8 +463,8 @@ func ex2b_test_declare_animal_internal{syscall_ptr : felt*, pedersen_ptr : HashB
 	alloc_locals
 	# Retrieve expected characteristics
 	let (expected_sex) = assigned_sex_number(sender_address)
-	let (expected_wings) = assigned_wings_number(sender_address)
 	let (expected_legs) = assigned_legs_number(sender_address)
+	let (expected_wings) = assigned_wings_number(sender_address)
 
 	# Retrieve exercise address
 	let (submited_exercise_address) = student_exercise_solution_storage.read(sender_address)
@@ -476,11 +476,11 @@ func ex2b_test_declare_animal_internal{syscall_ptr : felt*, pedersen_ptr : HashB
 	assert evaluator_address = token_owner
 
 	# Reading animal characteristic in student solution
-	let (read_sex, read_wings, read_legs) = IExerciceSolution.get_animal_characteristics(contract_address = submited_exercise_address, token_id=token_id)
+	let (read_sex, read_legs, read_wings) = IExerciceSolution.get_animal_characteristics(contract_address = submited_exercise_address, token_id=token_id)
 	# Checking characteristics are correct
 	assert read_sex = expected_sex
-	assert read_wings = expected_wings
 	assert read_legs = expected_legs
+	assert read_wings = expected_wings
 
 	# Checking if student has validated this exercise before
 	let (has_validated) = exercises_validation_storage.read(sender_address, 2)


### PR DESCRIPTION
Evaluator and interface expected or defined animal characteristics in different
orders.
This commits uniformizes these overall to Sex / Legs / Wings as defined in Interface.

! See discussion in #4 for likely another PR to expect (before redeploying the contracts?).

Also a few typos in readme
